### PR TITLE
Minor fix in nblast documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,6 @@ Suggests:
 License: GPL-3
 LazyData: yes
 VignetteBuilder: knitr
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.2
 Language: en-GB
 Encoding: UTF-8

--- a/R/neuriteblast.r
+++ b/R/neuriteblast.r
@@ -32,7 +32,7 @@
 #'   across cores of the same machine. Before using this, the backend must be
 #'   registered using \code{registerDoMC} (see example below).
 #'
-#' @param query the query neuron.
+#' @param query the query neuron, or neurons (\code{\link[nat]{neuronlist}}).
 #' @param target a \code{\link[nat]{neuronlist}} to compare neuron against.
 #'   Defaults to \code{options("nat.default.neuronlist")}. See
 #'   \code{\link{nat-package}}.

--- a/man/nat.nblast-package.Rd
+++ b/man/nat.nblast-package.Rd
@@ -5,9 +5,6 @@
 \alias{nat.nblast-package}
 \alias{nat.nblast}
 \title{Neuron similarity, search and clustering tools}
-\description{
-Neuron similarity, search and clustering tools
-}
 \section{Similarity and search}{
 
 

--- a/man/nblast.Rd
+++ b/man/nblast.Rd
@@ -17,7 +17,7 @@ nblast(
 )
 }
 \arguments{
-\item{query}{the query neuron.}
+\item{query}{the query neuron, or neurons (\code{\link[nat]{neuronlist}}).}
 
 \item{target}{a \code{\link[nat]{neuronlist}} to compare neuron against.
 Defaults to \code{options("nat.default.neuronlist")}. See


### PR DESCRIPTION
Making clear that the `nblast` function accepts also a neuronlist - to avoid the situation from flyconnectome slack (Mon, 19 Apr 22).