### PR TITLE
Quick fix in normalised scoring for cases where nrns/dps unnamed

### DIFF
--- a/R/scoremats.r
+++ b/R/scoremats.r
@@ -26,6 +26,8 @@ sub_score_mat <- function(query, target, scoremat=NULL, distance=FALSE, normalis
   if(!identical(length(dim(scoremat)),2L)) stop("scoremat must be a matrix!")
 
   # Check for missing query and target neurons
+  if (is.null(rownames(scoremat)))
+    rownames(scoremat) <- as.character(1:nrow(scoremat))
   rnames <- rownames(scoremat)
   if(missing(target)) target <- rnames
   else {
@@ -35,6 +37,8 @@ sub_score_mat <- function(query, target, scoremat=NULL, distance=FALSE, normalis
       target <- intersect(target, rnames)
     }
   }
+  if (is.null(colnames(scoremat)))
+    colnames(scoremat) <- as.character(1:ncol(scoremat))
   cnames=colnames(scoremat)
   if(missing(query)) query <- cnames
   else {

--- a/tests/testthat/test-NBLAST2.r
+++ b/tests/testthat/test-NBLAST2.r
@@ -60,6 +60,10 @@ test_that("we can calculate normalised nblast v2 scores", {
   expect_equal(nblast(testneurons[1], testneurons[3:5], version = 2, normalised = T),
                baseline)
 
+  names(testneurons) <- NULL
+  scoresaba <- nblast_allbyall(testneurons, version=2,
+                               normalisation = 'normalised')
+  expect_equal(dim(scoresaba), c(5, 5))
 })
 
 test_that("we can calculate scores for regular neurons",{


### PR DESCRIPTION
Quick fix in normalised scoring for cases where neurons or dotprops have no names.

Fixes #47 .